### PR TITLE
Fix block comment delimiters being split apart by the formatter

### DIFF
--- a/examples/fantom/issue-16-expected.fan
+++ b/examples/fantom/issue-16-expected.fan
@@ -1,0 +1,24 @@
+class Widget
+{
+  Void configure()
+  {
+    x := 1
+
+    // Block comment spanning multiple lines should not have its
+    // delimiters split apart.
+    /*
+    y := 2
+    z := 3
+    */
+
+    // Block comments can nest.
+    /*
+    a := 1
+    /* still commented out */
+    b := 2
+    */
+
+    w := 4 /* trailing note */
+    echo(x)
+  }
+}

--- a/examples/fantom/issue-16.fan
+++ b/examples/fantom/issue-16.fan
@@ -1,0 +1,24 @@
+class Widget
+{
+  Void configure()
+  {
+    x := 1
+
+    // Block comment spanning multiple lines should not have its
+    // delimiters split apart.
+    /*
+    y := 2
+    z := 3
+    */
+
+    // Block comments can nest.
+    /*
+    a := 1
+    /* still commented out */
+    b := 2
+    */
+
+    w := 4 /* trailing note */
+    echo(x)
+  }
+}

--- a/examples/fantom/run-tests.mjs
+++ b/examples/fantom/run-tests.mjs
@@ -12,6 +12,7 @@ const cases = [
   ["issue-13.fan", "issue-13-expected.fan"],
   ["issue-14.fan", "issue-14-expected.fan"],
   ["issue-15.fan", "issue-15-expected.fan"],
+  ["issue-16.fan", "issue-16-expected.fan"],
 ];
 
 let failed = 0;

--- a/src/fantom-ast-printer.js
+++ b/src/fantom-ast-printer.js
@@ -466,7 +466,7 @@ function printFieldDef(field, sourceLines) {
   if (initText !== null) {
     // Has `:=` init
     const initLines = initText.split("\n");
-    const fmtState = { inBlockComment: false, inTripleString: false };
+    const fmtState = { blockCommentDepth: 0, inTripleString: false };
     if (initLines.length === 1) {
       const formattedInit = formatLine(initLines[0].trim(), fmtState);
       lines.push(`${header} := ${formattedInit}`);
@@ -978,7 +978,7 @@ function reindentBlock(text, targetIndent) {
   }
   if (indentUnit === 0) indentUnit = 2; // flat or all-continuation block — use 2-space default
 
-  const state = { inBlockComment: false, inTripleString: false };
+  const state = { blockCommentDepth: 0, inTripleString: false };
   const result = [];
   let crossLineParenDepth = 0; // track open parens spanning multiple lines for semicolon guarding
   parenD = 0; // reuse parenD — reset for main pass (structural check)

--- a/src/fantom-formatter.js
+++ b/src/fantom-formatter.js
@@ -98,14 +98,25 @@ function isIdentifierPart(ch) {
 
 function splitCodeAndComment(line, state) {
   let i = 0;
+  // Index where the (single, trailing) comment span begins, once we've seen
+  // one. Fantom block comments nest ("/* outer /* inner */ still outer */"),
+  // so `blockCommentDepth` counts open `/*` markers rather than a plain
+  // in/out flag - a lone `*/` only closes the innermost one.
+  let commentStart = state.blockCommentDepth > 0 ? 0 : -1;
+
   while (i < line.length) {
-    if (state.inBlockComment) {
-      const end = line.indexOf("*/", i);
-      if (end === -1) {
-        return { code: line, comment: "", state };
+    if (state.blockCommentDepth > 0) {
+      if (line.startsWith("/*", i)) {
+        state.blockCommentDepth += 1;
+        i += 2;
+        continue;
       }
-      state.inBlockComment = false;
-      i = end + 2;
+      if (line.startsWith("*/", i)) {
+        state.blockCommentDepth -= 1;
+        i += 2;
+        continue;
+      }
+      i += 1;
       continue;
     }
 
@@ -126,7 +137,10 @@ function splitCodeAndComment(line, state) {
     }
 
     if (line.startsWith("/*", i)) {
-      state.inBlockComment = true;
+      if (commentStart === -1) {
+        commentStart = i;
+      }
+      state.blockCommentDepth = 1;
       i += 2;
       continue;
     }
@@ -169,6 +183,16 @@ function splitCodeAndComment(line, state) {
     }
 
     i += 1;
+  }
+
+  // A block comment that opened on this line (or continued from a previous
+  // one) - whether or not it went on to close before end of line - is
+  // reported as a trailing comment span so the code side never contains a
+  // stray "/*" or "*/" for the token-based code formatter to mangle. Any real
+  // code that happens to follow a same-line closing "*/" rides along
+  // unformatted inside that span rather than being lost.
+  if (commentStart !== -1) {
+    return { code: line.slice(0, commentStart), comment: line.slice(commentStart), state };
   }
 
   return { code: line, comment: "", state };
@@ -704,7 +728,7 @@ function splitCloseBraceContinuations(formatted) {
 function rewriteControlTransitions(formatted) {
   const lines = formatted.replace(/\n$/, "").split("\n");
   const out = [];
-  const state = { inBlockComment: false, inTripleString: false };
+  const state = { blockCommentDepth: 0, inTripleString: false };
 
   for (const line of lines) {
     const split = splitCodeAndComment(line, state);
@@ -753,7 +777,7 @@ export { formatLine, splitCodeAndComment, normalizeParamListText, normalizeCtorC
 export function formatFantomBase(source, options = {}) {
   const text = normalizeNewlines(source);
   const lines = text.split("\n");
-  const state = { inBlockComment: false, inTripleString: false };
+  const state = { blockCommentDepth: 0, inTripleString: false };
   const out = [];
 
   let indentLevel = 0;
@@ -789,7 +813,7 @@ export function formatFantomBase(source, options = {}) {
     blankRun = 0;
 
     const preview = splitCodeAndComment(rawLine, {
-      inBlockComment: state.inBlockComment,
+      blockCommentDepth: state.blockCommentDepth,
       inTripleString: state.inTripleString,
     });
     const deltas = countStructuralDeltas(preview.code);
@@ -1346,7 +1370,7 @@ function normalizeMethodHeaderLine(line) {
 }
 
 function codePortionEnd(line) {
-  const split = splitCodeAndComment(line, { inBlockComment: false, inTripleString: false });
+  const split = splitCodeAndComment(line, { blockCommentDepth: 0, inTripleString: false });
   return split.code.length;
 }
 
@@ -1365,7 +1389,7 @@ function rewriteMethodSignaturesWithAst(formatted, source, ast) {
     }
     const original = lines[idx];
     const indent = (original.match(/^\s*/) ?? [""])[0];
-    const split = splitCodeAndComment(original, { inBlockComment: false, inTripleString: false });
+    const split = splitCodeAndComment(original, { blockCommentDepth: 0, inTripleString: false });
     const codeTrim = split.code.trim();
     if (codeTrim === "") {
       return false;
@@ -1489,7 +1513,7 @@ function rewriteFieldDeclarationsWithAst(formatted, source, ast) {
     }
     const original = lines[idx];
     const indent = (original.match(/^\s*/) ?? [""])[0];
-    const split = splitCodeAndComment(original, { inBlockComment: false, inTripleString: false });
+    const split = splitCodeAndComment(original, { blockCommentDepth: 0, inTripleString: false });
     const codeTrim = split.code.trim();
     if (codeTrim === "") {
       return false;
@@ -1554,7 +1578,7 @@ function rewriteFieldDeclarationsWithAst(formatted, source, ast) {
 function rewriteUnbracedControlBodies(formatted, options = {}) {
   const lines = formatted.replace(/\n$/, "").split("\n");
   const out = [];
-  const state = { inBlockComment: false, inTripleString: false };
+  const state = { blockCommentDepth: 0, inTripleString: false };
 
   // Pattern: a line whose code portion is solely a control keyword (no trailing {).
   const CONTROL_CONTINUATION = /^(finally\s*$|catch\b)/;
@@ -1665,7 +1689,7 @@ function rewriteUnbracedControlBodies(formatted, options = {}) {
 function rewriteControlBraceStyle(formatted) {
   const lines = formatted.replace(/\n$/, "").split("\n");
   const out = [];
-  const state = { inBlockComment: false, inTripleString: false };
+  const state = { blockCommentDepth: 0, inTripleString: false };
 
   for (const line of lines) {
     const split = splitCodeAndComment(line, state);
@@ -1889,7 +1913,7 @@ function rewriteSingleLineControlBodiesWithAst(formatted, ast, options) {
     }
 
     const original = lines[idx];
-    const split = splitCodeAndComment(original, { inBlockComment: false, inTripleString: false });
+    const split = splitCodeAndComment(original, { blockCommentDepth: 0, inTripleString: false });
     const code = split.code;
     const comment = split.comment;
     const keywordRe = new RegExp(`\\b${node.keyword}\\b`);
@@ -1975,7 +1999,7 @@ function rewriteControlHeadersWithAst(formatted, ast) {
     }
 
     const original = lines[idx];
-    const split = splitCodeAndComment(original, { inBlockComment: false, inTripleString: false });
+    const split = splitCodeAndComment(original, { blockCommentDepth: 0, inTripleString: false });
     const code = split.code;
     const comment = split.comment;
     const start = Math.max(0, node.col - 1);


### PR DESCRIPTION
## Problem

`AntrumEyeBoot.fan` has a `/* ... */` block comment used to comment out a whole section (a common Fantom idiom - block comments can nest, per the language docs). Running it through this plugin turned the delimiters into `/ *` and `* /`, which no longer parses as a comment.

## Root cause

`splitCodeAndComment()` in `src/fantom-formatter.js` tracked block-comment state with a plain boolean (`inBlockComment`) and, regardless of that state, always fell through to a final `return { code: line, comment: "", state }` - mislabeling any line touched by a `/* */` comment as pure code. That handed `/*`/`*/` to the token-based code formatter, which split them into separate `/` and `*` operator tokens and rejoined them with a space.

## Fix

- Replaced the boolean with `state.blockCommentDepth` (a counter), so nested block comments (`/* outer /* inner */ still outer */`) are tracked correctly - a `*/` only closes the innermost open comment.
- Rewrote the scan to record where a comment span starts and return `{ code: line.slice(0, commentStart), comment: line.slice(commentStart) }`, mirroring how trailing `//` comments were already handled, instead of ever mislabeling a comment-bearing line as all-code.
- Renamed the field consistently everywhere state objects are constructed (`fantom-ast-printer.js` shares the same helpers).

This also fixes the same corruption for a `/* ... */` note trailing on a code line (e.g. `w := 4 /* trailing note */`), which was silently broken before too, not just the whole-line case.

## Testing

- Added `examples/fantom/issue-16.fan` covering multi-line, nested, and same-line trailing block comments as a regression test.
- `npm test` - all 5 cases pass.
- Confirmed `AntrumEyeBoot.fan` round-trips its `/* ... */` block unchanged.
- Diffed formatter output against pre-fix behavior on the plugin's own `example.fan`; the only remaining diff is a pre-existing, unrelated blank-line idempotency quirk present before this change too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)