### PR TITLE
Fix multi-line triple-quoted strings losing indentation in Trio/Axon src fields

### DIFF
--- a/examples/trio/multiline-string-expected.trio
+++ b/examples/trio/multiline-string-expected.trio
@@ -1,0 +1,11 @@
+name: multilineTripleQuoteString
+func
+src:
+  () => do
+    {val:
+    """1. First step
+       2. Second step
+         extra-indented nested detail
+       3. Third step
+       """}.toGrid
+  end

--- a/examples/trio/multiline-string.trio
+++ b/examples/trio/multiline-string.trio
@@ -1,0 +1,11 @@
+name: multilineTripleQuoteString
+func
+src:
+  () => do
+    {val:
+    """1. First step
+       2. Second step
+         extra-indented nested detail
+       3. Third step
+       """}.toGrid
+  end

--- a/examples/trio/run-tests.mjs
+++ b/examples/trio/run-tests.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import prettier from "prettier";
+import plugin from "../../src/index.js";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const cases = [["multiline-string.trio", "multiline-string-expected.trio"]];
+
+let failed = 0;
+
+for (const [inputName, expectedName] of cases) {
+  const inputPath = path.join(root, inputName);
+  const expectedPath = path.join(root, expectedName);
+  const input = fs.readFileSync(inputPath, "utf8");
+  const expected = fs.readFileSync(expectedPath, "utf8");
+  const format = (text) => prettier.format(text, { parser: "trio-parse", plugins: [plugin], printWidth: 120 });
+
+  const actual = await format(input);
+  if (actual !== expected) {
+    failed += 1;
+    console.error(`FAIL ${inputName}`);
+    console.error("--- expected ---");
+    console.error(expected);
+    console.error("--- actual ---");
+    console.error(actual);
+    continue;
+  }
+
+  // A dedented block comment/multi-line-string bug can format cleanly once
+  // but produce output that no longer re-parses (or drifts) on a second
+  // pass, since the axon source is now indented differently than it was in
+  // the hand-written original. Guard against that regression directly.
+  const reformatted = await format(actual);
+  if (reformatted !== actual) {
+    failed += 1;
+    console.error(`FAIL ${inputName} (not idempotent on second format pass)`);
+    console.error("--- first pass ---");
+    console.error(actual);
+    console.error("--- second pass ---");
+    console.error(reformatted);
+    continue;
+  }
+
+  console.log(`PASS ${inputName}`);
+}
+
+if (failed > 0) {
+  process.exit(1);
+}
+
+console.log(`All ${cases.length} Trio formatting tests passed.`);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/node": "*"
   },
   "scripts": {
-    "test": "node examples/fantom/run-tests.mjs",
+    "test": "node examples/fantom/run-tests.mjs && node examples/trio/run-tests.mjs",
     "trio": "prettier --plugin ./src/index.js --print-width 120 examples/trio/example.trio",
     "fantom": "prettier --plugin ./src/index.js --print-width 120 examples/fantom/example.fan"
   }

--- a/src/axon-formatter.js
+++ b/src/axon-formatter.js
@@ -107,7 +107,34 @@ export function printAxon(path, options, print) {
             start++;
             end--;
           }
-          return options.originalText.substring(start, end + 1);
+          const raw = options.originalText.substring(start, end + 1);
+          // Multi-line literals (triple-quoted strings) embed real newlines.
+          // Axon requires every continuation line to be indented to at least
+          // the column where the string's content starts (3 chars past the
+          // opening '"""'), and that column depends on wherever the opening
+          // delimiter itself ends up printed - which this printer can't
+          // otherwise know if arbitrary text (e.g. "key: ") precedes it on
+          // the same line. So we always force the delimiter onto its own
+          // fresh line (flush with whatever indent is active there), and
+          // reproduce each continuation line's *original* offset relative to
+          // that delimiter's original column - preserving both the required
+          // minimum alignment and any deliberate extra indentation the
+          // author put in the string's content - regardless of how the
+          // surrounding expression gets reformatted.
+          if (raw.includes("\n")) {
+            const lineStart = options.originalText.lastIndexOf("\n", start - 1) + 1;
+            const openingOffset = start - lineStart;
+            const rawLines = raw.split("\n");
+            const pieces = [rawLines[0]];
+            for (let i = 1; i < rawLines.length; i++) {
+              const line = rawLines[i];
+              const lineIndent = line.length - line.trimStart().length;
+              const delta = Math.max(lineIndent - openingOffset, 3);
+              pieces.push(pb.hardline, " ".repeat(delta), line.slice(lineIndent));
+            }
+            return [pb.hardline, ...pieces];
+          }
+          return raw;
         }
         return path.call(print, "val");
 

--- a/src/axon-formatter.js
+++ b/src/axon-formatter.js
@@ -108,19 +108,6 @@ export function printAxon(path, options, print) {
             end--;
           }
           const raw = options.originalText.substring(start, end + 1);
-          // Multi-line literals (triple-quoted strings) embed real newlines.
-          // Axon requires every continuation line to be indented to at least
-          // the column where the string's content starts (3 chars past the
-          // opening '"""'), and that column depends on wherever the opening
-          // delimiter itself ends up printed - which this printer can't
-          // otherwise know if arbitrary text (e.g. "key: ") precedes it on
-          // the same line. So we always force the delimiter onto its own
-          // fresh line (flush with whatever indent is active there), and
-          // reproduce each continuation line's *original* offset relative to
-          // that delimiter's original column - preserving both the required
-          // minimum alignment and any deliberate extra indentation the
-          // author put in the string's content - regardless of how the
-          // surrounding expression gets reformatted.
           if (raw.includes("\n")) {
             const lineStart = options.originalText.lastIndexOf("\n", start - 1) + 1;
             const openingOffset = start - lineStart;


### PR DESCRIPTION
## Problem

Reformatting `lib/antrumClusterComm/funcs.trio` in AntrumEyeBoot (a file that parsed fine before) threw:

```
[error] lib/antrumClusterComm/funcs.trio: axon::SyntaxErr: Leading space in multi-line string must be 11 ["2"] [...funcs.trio:60]
```

It worked before running prettier - prettier itself introduced the break.

## Root cause

Axon requires every continuation line of a triple-quoted multi-line string to be indented to *at least* the column where the string's content starts (3 characters past the opening `"""`) - otherwise the lexer throws `Leading space in multi-line string must be N`. That required column depends entirely on wherever the opening `"""` itself ends up printed.

The `literal` expression case in `axon-formatter.js` returned the string's raw source text as a plain multi-line string, embedded inside the surrounding dict/call `pb.indent(...)`. On the *first* format pass, Prettier's dict-literal printer collapsed:

```
{val:
""" ...
```
onto one line:
```
{val: """ ...
```

which shifted the column the delimiter printed at. Because the raw text was a plain string (not built from `pb.literalline`/dynamic padding), Prettier's own doc-printing algorithm re-indented every embedded newline in it to whatever indent was structurally active at that point - which no longer matched what the continuation lines actually needed once the delimiter's column changed, corrupting the file.

## Fix

Since arbitrary same-line text (like `"key: "`) makes the delimiter's eventual print column impossible to know from inside the literal printer, the fix:

1. Forces the opening `"""` onto its own fresh line (flush with whatever indent is active there) instead of letting it get joined onto a preceding line.
2. Reproduces each continuation line's *original* offset relative to the delimiter's *original* column, as literal padding emitted after a `hardline`.

This preserves both the required minimum alignment and any deliberate extra indentation the author put into the string's content, regardless of how the surrounding expression gets reformatted.

## Testing

- `lib/antrumClusterComm/funcs.trio` (from AntrumEyeBoot) now round-trips byte-for-byte through the formatter and stays stable across a second format pass (this bug only shows up on reformatting already-formatted output, so idempotency is the real test).
- Added `examples/trio/multiline-string.trio` as a regression test, with a `run-tests.mjs` mirroring the existing Fantom test runner (wired into `npm test`), which explicitly asserts a second format pass doesn't change the output.
- `npm test` - all cases (Fantom + Trio) pass.
- No diff on the existing `examples/trio/example.trio` → `expected.trio` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)